### PR TITLE
Implement DDSketch.ComputeSerializedSize

### DIFF
--- a/src/Datadog.Sketches/DDSketch.cs
+++ b/src/Datadog.Sketches/DDSketch.cs
@@ -280,6 +280,14 @@ public class DDSketch
         return sum;
     }
 
+    internal int ComputeSerializedSize()
+    {
+        return Serializer.EmbeddedFieldSize(1, ((ISerializable)IndexMapping).ComputeSerializedSize())
+            + Serializer.EmbeddedFieldSize(2, ((ISerializable)PositiveValueStore).ComputeSerializedSize())
+            + Serializer.EmbeddedFieldSize(3, ((ISerializable)NegativeValueStore).ComputeSerializedSize())
+            + Serializer.DoubleFieldSize(4, ZeroCount);
+    }
+
     /// <summary>
     /// Produces protobuf encoded bytes which are equivalent to using the official protobuf bindings,
     /// without requiring a runtime dependency on a protobuf library.

--- a/src/Datadog.Sketches/Serialization/Serializer.cs
+++ b/src/Datadog.Sketches/Serialization/Serializer.cs
@@ -49,6 +49,11 @@ namespace Datadog.Sketches.Serialization
             _writer = new BinaryWriter(output, Encoding.UTF8, leaveOpen: true);
         }
 
+        public static int EmbeddedFieldSize(int fieldIndex, int size)
+        {
+            return TagSize(fieldIndex, LengthDelimited) + EmbeddedSize(size);
+        }
+
         public static int EmbeddedSize(int size)
         {
             return VarIntLength(size) + 1 + size;

--- a/tests/Datadog.Sketches.Tests/SerializerTests.cs
+++ b/tests/Datadog.Sketches.Tests/SerializerTests.cs
@@ -71,6 +71,8 @@ namespace Datadog.Sketches.Tests
 
         private void AssertEquals(DDSketch sketch, byte[] buffer)
         {
+            sketch.ComputeSerializedSize().Should().Be(buffer.Length);
+
             var protoSketch = ProtobufHelpers.ToProto(sketch);
 
             using (var stream = new MemoryStream())


### PR DESCRIPTION
Implement `DDSketch.ComputeSerializedSize`, to precompute the serialized size.

I initially omitted it because I thought I wouldn't need it, turns out I was wrong.