### PR TITLE
fix merging different store types

### DIFF
--- a/src/Datadog.Sketches/Stores/CollapsingHighestDenseStore.cs
+++ b/src/Datadog.Sketches/Stores/CollapsingHighestDenseStore.cs
@@ -34,7 +34,7 @@ public class CollapsingHighestDenseStore : CollapsingDenseStore
         }
         else
         {
-            foreach (var bin in EnumerateAscending())
+            foreach (var bin in store.EnumerateAscending())
             {
                 Add(bin);
             }

--- a/src/Datadog.Sketches/Stores/CollapsingLowestDenseStore.cs
+++ b/src/Datadog.Sketches/Stores/CollapsingLowestDenseStore.cs
@@ -37,7 +37,7 @@ public class CollapsingLowestDenseStore : CollapsingDenseStore
         }
         else
         {
-            foreach (var bin in EnumerateDescending())
+            foreach (var bin in store.EnumerateDescending())
             {
                 Add(bin);
             }

--- a/tests/Datadog.Sketches.Tests/Stores/StoreTests.cs
+++ b/tests/Datadog.Sketches.Tests/Stores/StoreTests.cs
@@ -161,6 +161,17 @@ public abstract class StoreTests
     }
 
     [Test]
+    public void TestMergingDifferentStoreTypes()
+    {
+        var clHist = new CollapsingLowestDenseStore(1);
+        var chHist = new CollapsingHighestDenseStore(1);
+        clHist.Add(0, 3);
+        chHist.Add(0, 5);
+        clHist.MergeWith(chHist);
+        clHist.Counts[0].Should().Be(8);
+    }
+
+    [Test]
     public void TestCopyingEmpty()
     {
         var store = NewStore();


### PR DESCRIPTION
Hi, y'all.  Thanks for the super useful implementation!

I was working on a migration of some code, and was looking at the internals of the library.  I happened to notice the `MergeWith()` methods of the two concrete dense stores were broken.  They're merging themselves with themselves.  The fix is simple: use "that" instead of "this".

I added a unit test that fails without the fix, and passes with the fix.  I wasn't sure where to put it, though, as StoreTests.cs gets included in the individual class tests.

Anywho, I know this library is marked as to-be-archived, but I thought I'd submit a PR for posterity.